### PR TITLE
Separate out crictl configuration instructions

### DIFF
--- a/docs/demos/opc-thermometer-demo.md
+++ b/docs/demos/opc-thermometer-demo.md
@@ -127,11 +127,14 @@ Now, we must create some OPC UA Servers to discover. Instead of starting from sc
 
    sure to set the appropriate IP address and port number for the DiscoveryURLs in the Helm command below. If using
 
-   security, uncomment `--set opcua.configuration.mountCertificates='true'`.   
+   security, uncomment `--set opcua.configuration.mountCertificates='true'`.  
 
+   > Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+    
    ```bash
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set opcua.discovery.enabled=true \
         --set opcua.configuration.enabled=true \
         --set opcua.configuration.name=akri-opcua-monitoring \
@@ -289,6 +292,7 @@ To see how Akri easily scales as nodes are added to the cluster, add another nod
 
    ```bash
    helm upgrade akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set opcua.discovery.enabled=true \
         --set opcua.configuration.enabled=true \
         --set opcua.configuration.name=akri-opcua-monitoring \
@@ -341,6 +345,7 @@ Make sure you have restarted your OPC UA Servers, since they attempt to register
 
 ```bash
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.name=akri-opcua-monitoring \
@@ -369,6 +374,7 @@ Instead of deploying brokers to all servers registered with specified Local Disc
 
 ```bash
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.name=akri-opcua-monitoring \
@@ -381,10 +387,13 @@ helm install akri akri-helm-charts/akri \
     # --set opcua.configuration.mountCertificates='true'
 ```
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 Alternatively, to only discover the server named "SomeServer0", do the following:
 
 ```bash
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.name=akri-opcua-monitoring \
@@ -404,6 +413,7 @@ The OPC UA Monitoring broker and anomaly detection application support a very sp
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.discoveryUrls[0]="opc.tcp://<IP address>:<port>/" \

--- a/docs/demos/usb-camera-demo-rpi4.md
+++ b/docs/demos/usb-camera-demo-rpi4.md
@@ -107,9 +107,13 @@ All of Akri's components can be deployed by specifying values in its Helm chart 
 In order for the Agent to know how to discover video devices, the udev Discovery Handler must exist. Akri supports an Agent image that includes all supported Discovery Handlers. This Agent will be used if `agent.full=true` is set. By default, a slim Agent without any embedded Discovery Handlers is deployed and the required Discovery Handlers can be deployed as DaemonSets. This demo will use that strategy, deploying the udev Discovery Handlers by specifying `udev.discovery.enabled=true` when installing Akri.
 
 1. Add the Akri Helm chart and run the install command, setting Helm values as described above.
+
+    > Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+    
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set udev.discovery.enabled=true \
         --set udev.configuration.enabled=true \
         --set udev.configuration.name=akri-udev-video \
@@ -196,6 +200,7 @@ Look at the Configuration and Instances in more detail.
    ```bash
    helm repo add akri-helm-charts https://deislabs.github.io/akri/
    helm install akri akri-helm-charts/akri \
+      $AKRI_HELM_CRICTL_CONFIGURATION \
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \
@@ -207,6 +212,7 @@ Look at the Configuration and Instances in more detail.
    ```bash
    helm repo add akri-helm-charts https://deislabs.github.io/akri/
    helm install akri akri-helm-charts/akri \
+      $AKRI_HELM_CRICTL_CONFIGURATION \
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \

--- a/docs/demos/usb-camera-demo.md
+++ b/docs/demos/usb-camera-demo.md
@@ -105,6 +105,8 @@ In order for the Agent to know how to discover video devices, the udev Discovery
 
 1. Add the Akri Helm chart and run the install command, setting Helm values as described above.
 
+   > Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+   
    ```bash
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
@@ -260,6 +262,7 @@ After installing Akri, since the /dev/video1 and /dev/video2 devices are running
    ```bash
    helm repo add akri-helm-charts https://deislabs.github.io/akri/
    helm install akri akri-helm-charts/akri \
+      $AKRI_HELM_CRICTL_CONFIGURATION \
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \
@@ -271,6 +274,7 @@ After installing Akri, since the /dev/video1 and /dev/video2 devices are running
    ```bash
    helm repo add akri-helm-charts https://deislabs.github.io/akri/
    helm install akri akri-helm-charts/akri \
+      $AKRI_HELM_CRICTL_CONFIGURATION \
       --set udev.discovery.enabled=true \
       --set udev.configuration.enabled=true \
       --set udev.configuration.name=akri-udev-video \

--- a/docs/development/broker-development.md
+++ b/docs/development/broker-development.md
@@ -37,9 +37,12 @@ A broker can expose information via REST, gRPC, etc. Akri's [sample brokers](htt
 
 Once you have created a broker, you can ask Akri to automatically deploy it to all all devices discovered by a Configuration by specifying the image in `<Discovery Handler name>.configuration.brokerPod.image.repository` and `<Discovery Handler name>.configuration.brokerPod.image.tag`. For example, say you created a broker that connects to a USB camera and advertises it as an IP camera. You want to deploy it to all USB cameras on your cluster's nodes using Akri, so you deploy Akri with a Configuration that uses the udev Discovery Handler and set the image of your broker (say `ghcr.io/brokers/camera-broker:v0.0.1`), like so:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri-dev \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.name=akri-udev-video \
@@ -68,6 +71,7 @@ You can request that additional environment variables are set in Pods that reque
 ```bash
   helm repo add akri-helm-charts https://deislabs.github.io/akri/
   helm install akri akri-helm-charts/akri-dev \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
   --set udev.discovery.enabled=true \
   --set udev.configuration.enabled=true \
   --set udev.configuration.name=akri-udev-video \

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -171,6 +171,7 @@ There are two steps to this. For the sake of this demonstration, only the amd64 
     # Specify repository as $PREFIX/<component>
     # Specify tag as $LABEL_PREFIX-amd64
     helm install akri ./deployment/helm \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set agent.image.pullPolicy=Never \
         --set agent.image.repository="$PREFIX/agent" \
         --set agent.image.tag="$LABEL_PREFIX-amd64" \

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -16,9 +16,12 @@ Since the Debug Echo Discovery Handler is for debugging, its use must be explici
 
 To install Akri with **external** Debug Echo Discovery Handlers and a Configuration to discover unshared Debug Echo devices, run:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set agent.allowDebugEcho=true \
     --set debugEcho.discovery.enabled=true \
     --set debugEcho.configuration.enabled=true \
@@ -31,6 +34,7 @@ To instead install Akri with Debug Echo Discovery Handlers embedded in the Agent
 ```text
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
   --set agent.allowDebugEcho=true \
   --set agent.full=true \
   --set debugEcho.configuration.enabled=true \

--- a/docs/development/development-walkthrough.md
+++ b/docs/development/development-walkthrough.md
@@ -412,11 +412,12 @@ sudo helm delete akri
 
 Akri has provided helm templates for custom Discovery Handlers and their Configurations. These templates are provided as a starting point. They may need to be modified to meet the needs of a Discovery Handler. When installing Akri, specify that you want to deploy a custom Discovery Handler as a DaemonSet by setting `custom.discovery.enabled=true`. Specify the container for that DaemonSet as the HTTP discovery handler that you built [above](development-walkthrough.md#build-the-discoveryhandler-container) by setting `custom.discovery.image.repository=$DH_IMAGE` and `custom.discovery.image.repository=$TAGS`. To automatically deploy a custom Configuration, set `custom.configuration.enabled=true`. We will customize this Configuration to contain the discovery endpoint needed by our HTTP Discovery Handler by setting it in the `discovery_details` string of the Configuration, like so: `custom.configuration.discoveryDetails=http://discovery:9999/discovery`. We also need to set the name the Discovery Handler will register under (`custom.configuration.discoveryHandlerName`) and a name for the Discovery Handler and Configuration (`custom.discovery.name` and `custom.configuration.name`). All these settings come together as the following Akri installation command:
 
-> Note: Be sure to consult the [user guide](../user-guide/getting-started.md) to see whether your Kubernetes distribution needs any additional configuration.
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
 
 ```bash
   helm repo add akri-helm-charts https://deislabs.github.io/akri/
   helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set imagePullSecrets[0].name="crPullSecret" \
     --set custom.discovery.enabled=true  \
     --set custom.discovery.image.repository=$DH_IMAGE \
@@ -438,6 +439,7 @@ If you simply wanted Akri to expose discovered devices to the cluster as Kuberne
 
 ```bash
   helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set imagePullSecrets[0].name="crPullSecret" \
     --set custom.discovery.enabled=true  \
     --set custom.discovery.image.repository=$DH_IMAGE \
@@ -626,6 +628,7 @@ Now that the HTTP broker has been created, we can substitute it's image in for t
 
 ```bash
   helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set imagePullSecrets[0].name="crPullSecret" \
     --set custom.discovery.enabled=true  \
     --set custom.discovery.image.repository=$DH_IMAGE \

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -193,6 +193,7 @@ When installing Akri using helm, you can set the `imagePullSecrets`, `image.repo
 kubectl create secret docker-registry <your-secret-name> --docker-server=ghcr.io  --docker-username=<your-github-alias> --docker-password=<your-github-token>
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri-dev \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set imagePullSecrets[0].name="<your-secret-name>" \
     --set agent.image.repository="ghcr.io/<your-github-alias>/agent" \
     --set agent.image.tag="v<akri-version>-amd64" \
@@ -207,6 +208,7 @@ More information about the Akri Helm charts can be found in the [user guide](../
 If you make changes to anything in the [helm folder](https://github.com/deislabs/akri/tree/main/deployment/helm), you will probably need to create a new Helm chart for Akri. This can be done using the [`helm package`](https://helm.sh/docs/helm/helm_package/) command. To create a chart using the current state of the Helm templates and CRDs, run (from one level above the Akri directory) `helm package akri/deployment/helm/`. You will see a tgz file called `akri-<akri-version>.tgz` at the location where you ran the command. Now, install Akri using that chart:
 ```sh
 helm install akri akri-<akri-version>.tgz \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set useLatestContainers=true
 ```
 ### Helm Template

--- a/docs/development/handler-development.md
+++ b/docs/development/handler-development.md
@@ -176,6 +176,7 @@ Also set the name the Discovery Handler will register under (`custom.configurati
 ```bash
   helm repo add akri-helm-charts https://deislabs.github.io/akri/
   helm install akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
   --set imagePullSecrets[0].name="crPullSecret" \
   --set custom.discovery.enabled=true  \
   --set custom.discovery.image.repository=$DH_IMAGE \
@@ -190,8 +191,11 @@ Also set the name the Discovery Handler will register under (`custom.configurati
 {% hint style="info" %}
 Note: if your Discovery Handler's `discoveryDetails` cannot be easily set using Helm, generate a Configuration file and modify it as needed. configuration.enabled\`.)
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
   helm install akri akri-helm-charts/akri \
+   $AKRI_HELM_CRICTL_CONFIGURATION \
    --set imagePullSecrets[0].name="crPullSecret" \
    --set custom.discovery.enabled=true  \
    --set custom.discovery.image.repository=$DH_IMAGE \
@@ -228,6 +232,7 @@ If you simply wanted Akri to expose discovered devices to the cluster as Kuberne
 
 ```bash
   helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set imagePullSecrets[0].name="crPullSecret" \
     --set custom.discovery.enabled=true  \
     --set custom.discovery.image.repository=$DH_IMAGE \

--- a/docs/discovery-handlers/onvif.md
+++ b/docs/discovery-handlers/onvif.md
@@ -66,9 +66,12 @@ By default, if a broker Pod is specified, a single broker Pod is deployed to eac
 
 Leveraging the above settings, Akri can be installed with the ONVIF Discovery Handler and an ONVIF Configuration that specifies the Akri frame server broker:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.discovery.enabled=true \
     --set onvif.configuration.enabled=true \
     --set onvif.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker" \
@@ -91,6 +94,7 @@ For example, the following enables discovery of every camera that does not have 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.discovery.enabled=true \
     --set onvif.configuration.enabled=true \
     --set onvif.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker" \
@@ -103,6 +107,7 @@ You can enable cluster access for every camera with a specific name, you can mod
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.discovery.enabled=true \
     --set onvif.configuration.enabled=true \
     --set onvif.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker" \
@@ -118,6 +123,7 @@ The ONVIF Discovery Handler will search for up to `discoveryTimeoutSeconds` for 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.discovery.enabled=true \
     --set onvif.configuration.enabled=true \
     --set onvif.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker" \

--- a/docs/discovery-handlers/opc-ua.md
+++ b/docs/discovery-handlers/opc-ua.md
@@ -64,9 +64,12 @@ By default, if a broker Pod is specified, a single broker Pod is deployed to eac
 
 Leveraging the above settings, Akri can be installed with the OPC UA Discovery Handler and an OPC UA Configuration that specifies discovery via the default LDS DiscoveryURL:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true
 ```
@@ -76,6 +79,7 @@ If you have a workload that you would like to automatically be deployed to each 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.brokerPod.image.repository=nginx
@@ -98,6 +102,7 @@ If no DiscoveryURLs are passed as Helm values, the default DiscoveryURL for Loca
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.discoveryUrls[0]="opc.tcp://10.1.2.3:4840/" \
@@ -111,6 +116,7 @@ If you know the DiscoveryURLs for the OPC UA Servers you want Akri to discover, 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.discoveryUrls[0]="opc.tcp://10.123.456.7:4855/"
@@ -123,6 +129,7 @@ OPC UA discovery can also receive a list of both OPC UA LDS DiscoveryURLs and sp
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.discoveryUrls[0]="opc.tcp://10.1.2.3:4840/" \
@@ -139,6 +146,7 @@ Instead of discovering all servers registered with specified Local Discovery Ser
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.applicationNames.action=Exclude \
@@ -150,6 +158,7 @@ Alternatively, to only discover the server named "Go Tar Heels!", do the followi
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.discoveryDetails.applicationNames.action=Include \
@@ -177,6 +186,7 @@ Finally, when mounting certificates is enabled with Helm via `--set opcua.config
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set opcua.discovery.enabled=true \
     --set opcua.configuration.enabled=true \
     --set opcua.configuration.mountCertificates='true'

--- a/docs/discovery-handlers/udev.md
+++ b/docs/discovery-handlers/udev.md
@@ -128,9 +128,12 @@ To test which devices Akri will discover with a udev rule, you can run the rule 
 
 Leveraging the above settings, Akri can be installed with the udev Discovery Handler and a udev Configuration with our udev rule specified.
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+   $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"'
@@ -150,6 +153,7 @@ The udev Discovery Handler will find all devices that are described by ANY of th
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \
@@ -165,6 +169,7 @@ Instead of manually deploying Pods to resources advertized by Akri, you can add 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \
@@ -182,6 +187,7 @@ By default in the generic udev Configuration, the udev broker is run in privileg
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \

--- a/docs/user-guide/customizing-an-akri-installation.md
+++ b/docs/user-guide/customizing-an-akri-installation.md
@@ -14,9 +14,12 @@ The [ONVIF](../discovery-handlers/onvif.md), [udev](../discovery-handlers/udev.m
 
 To install Akri without any protocol Configurations, run this:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
-helm install akri akri-helm-charts/akri
+helm install akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
 ```
 
 This will deploy the Akri Controller and deploy Akri Agents.
@@ -49,6 +52,7 @@ If you want your end application to consume frames from both IP cameras and loca
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.configuration.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"'
@@ -94,6 +98,7 @@ A Configuration can be modified by using the `helm upgrade` command. It upgrades
 
 ```bash
 helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.configuration.enabled=true \
     --set onvif.configuration.brokerPod.image.repository=<your broker image name> \
     --set onvif.configuration.brokerPod.image.tag=<your broker image tag> \
@@ -177,6 +182,7 @@ Another Configuration can be added to the cluster by using `helm upgrade`. For e
 
 ```bash
 helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.enabled=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"'
@@ -205,6 +211,7 @@ A Configuration can be deleted from a cluster using `helm upgrade`. For example,
 
 ```bash
 helm upgrade akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.enabled=true
 ```
 
@@ -238,6 +245,7 @@ The Agent discovers devices via Discovery Handlers. Akri supports an Agent image
 
 ```bash
 helm install akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
   --set agent.full=true
 ```
 
@@ -245,6 +253,7 @@ By default, a slim Agent without any embedded Discovery Handlers is deployed and
 
 ```bash
 helm install akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
   --set opcua.discovery.enabled=true \
   --set onvif.discovery.enabled=true
 ```

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -14,20 +14,25 @@ Starting in v0.0.36, an **akri-dev** Helm chart will be published for each build
 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
-helm install akri akri-helm-charts/akri-dev
+helm install akri akri-helm-charts/akri-dev \
+   $AKRI_HELM_CRICTL_CONFIGURATION
 ```
+
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
 
 Starting in Release v0.0.44, an **akri** Helm chart will be published for each [Release](https://github.com/deislabs/akri/releases). Releases will generally reflect milestones and will have more rigorous testing. You can deploy Release versions of Akri with this command (note: **akri**):
 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
-helm install akri akri-helm-charts/akri
+helm install akri akri-helm-charts/akri \
+   $AKRI_HELM_CRICTL_CONFIGURATION
 ```
 
 To use the latest containers of the Akri components, add `--set useLatestContainers=true` when installing Akri like so:
 
 ```bash
 helm install akri akri-helm-charts/akri \
+   $AKRI_HELM_CRICTL_CONFIGURATION \
    --set useLatestContainers=true
 ```
 
@@ -55,7 +60,7 @@ Let's walk through building an Akri installation command:
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
    ```
 
-2. Install Akri's Controller and Agent, specifying the crictl configuration from [the cluster setup steps](cluster-setup.md) in not using vanilla Kubernetes:
+2. Install Akri's Controller and Agent, specifying the crictl configuration from [the cluster setup steps](cluster-setup.md#configure-crictl) in not using vanilla Kubernetes:
 
    ```bash
      helm install akri akri-helm-charts/akri \
@@ -68,13 +73,15 @@ Let's walk through building an Akri installation command:
 
    ```bash
     helm upgrade akri akri-helm-charts/akri \
-        --set <discovery handler name>.discovery.enabled=true
+         $AKRI_HELM_CRICTL_CONFIGURATION \
+         --set <discovery handler name>.discovery.enabled=true
    ```
 
    > Note: To install a full Agent with embedded udev, OPC UA, and ONVIF Discovery Handlers, set `agent.full=true` instead of enabling the Discovery Handlers. Note, this we restart the Agent Pods.
    >
    > ```bash
    > helm upgrade akri akri-helm-charts/akri \
+   >    $AKRI_HELM_CRICTL_CONFIGURATION
    >    --set agent.full=true
    > ```
 
@@ -82,6 +89,7 @@ Let's walk through building an Akri installation command:
 
    ```bash
     helm upgrade akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION
         --set <discovery handler name>.discovery.enabled=true \
         --set <discovery handler name>.configuration.enabled=true \
         # set any discovery details in the Configuration
@@ -93,6 +101,7 @@ Installation could have been done in one step rather than a series of upgrades:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION
     --set <discovery handler name>.discovery.enabled=true \
     --set <discovery handler name>.configuration.enabled=true \
     # set any discovery details in the Configuration
@@ -103,6 +112,7 @@ As a real example, Akri's Controller, Agents, udev Discovery Handlers, and a ude
 
 ```bash
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION
     --set udev.discovery.enabled=true \
     --set udev.configuration.enabled=true \
     --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \

--- a/docs/user-guide/monitoring-with-prometheus.md
+++ b/docs/user-guide/monitoring-with-prometheus.md
@@ -39,9 +39,12 @@ The Akri Controller and Agent publish metrics to port 8080 at a `/metrics` endpo
 
 Install Akri and expose the Controller and Agent's metrics to Prometheus by running:
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set prometheus.enabled=true
 ```
 
@@ -95,6 +98,7 @@ As an example, an `akri_frame_count` metric has been created in the sample [udev
    ```bash
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set udev.enabled=true \
         --set udev.name=akri-udev-video \
         --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
@@ -109,6 +113,7 @@ As an example, an `akri_frame_count` metric has been created in the sample [udev
    >
    > > ```bash
    > > helm upgrade prometheus prometheus-community/kube-prometheus-stack \
+   > >   $AKRI_HELM_CRICTL_CONFIGURATION \
    > >   --set grafana.service.type=NodePort \
    > >   --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
    > >   --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \

--- a/docs/user-guide/requesting-akri-resources.md
+++ b/docs/user-guide/requesting-akri-resources.md
@@ -4,9 +4,12 @@ Akri discovers tiny devices, advertizes them as resources, and automatically dep
 
 Lets walk through how this works, using the ONVIF Discovery Handler as an example. Install Akri with the ONVIF Discovery Handler and Configuration, omitting a broker pod image.
 
+> Note: See [the cluster setup steps](cluster-setup.md#configure-crictl) for information on how to set the crictl configuration variable `AKRI_HELM_CRICTL_CONFIGURATION`
+
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
+    $AKRI_HELM_CRICTL_CONFIGURATION \
     --set onvif.discovery.enabled=true \
     --set onvif.configuration.enabled=true
 ```


### PR DESCRIPTION
This separates out instructions on storing `crictl` configuration Helm values in a `AKRI_HELM_CRICTL_CONFIGURATION` variable out from the rest of the cluster setup steps. The instructions are referenced at the top of every section that contains installations. It also adds the `AKRI_HELM_CRICTL_CONFIGURATION` variable to all installations.

This will reduce the amount of slot reconciliation errors people encounter.

Fixes deislabs/akri#97