### PR TITLE
Improve development documentation

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -23,7 +23,7 @@ Contributions can be made by forking the repository and creating a pull request.
 * the Akri tests all pass (`cargo test`)
 * the inline documentation builds (`cargo doc`)
 
-See the [Development](../development/development-walkthrough.md) documentation for more information on how to set up your environment and build Akri components locally.
+See the [Development](../development/development.md) documentation for more information on how to set up your environment and build Akri components locally.
 
 ## Versioning
 

--- a/docs/demos/opc-thermometer-demo.md
+++ b/docs/demos/opc-thermometer-demo.md
@@ -106,28 +106,17 @@ Now, we must create some OPC UA Servers to discover. Instead of starting from sc
 
 1. Make sure your OPC UA Servers are running
 2. Now it is time to install the Akri using Helm. When installing Akri, we can specify that we want to deploy the OPC UA
-
    Discovery Handlers by setting the helm value `opcua.discovery.enabled=true`. We also specify that we want to create
-
    an OPC UA Configuration with `--set opcua.configuration.enabled=true`. In the Configuration, any values that should
-
    be set as environment variables in brokers can be set in `opcua.configuration.brokerProperties`. In this scenario, we
-
    will specify the `Identifier` and `NamespaceIndex` of the NodeID we want the brokers to monitor. In our case that is
-
    our temperature variable we made earlier, which has an `Identifier` of `Thermometer_Temperature` and `NamespaceIndex`
-
    of `2`. Finally, since we did not set up a Local Discovery Server -- see \[Setting up and using a Local Discovery
-
    Server\](\#setting-up-and-using-a-local-discovery-server-(windows-only)) in the Extensions section at the bottom of
-
    this document to use a LDS -- we must specify the DiscoveryURLs of the OPC UA Servers we want Agent to discover.
-
-   Those are the tcp addresses that we modified in step 3 of [Creating OPC UA Servers](opc-thermometer-demo.md#creating-opc-ua-servers). Be
-
-   sure to set the appropriate IP address and port number for the DiscoveryURLs in the Helm command below. If using
-
-   security, uncomment `--set opcua.configuration.mountCertificates='true'`.   
+   Those are the tcp addresses that we modified in step 3 of [Creating OPC UA Servers](opc-thermometer-demo.md#creating-opc-ua-servers). 
+   Be sure to set the appropriate IP address and port number for the DiscoveryURLs in the Helm command below. If using security, 
+   uncomment `--set opcua.configuration.mountCertificates='true'`.   
 
    ```bash
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
@@ -167,7 +156,7 @@ Now, we must create some OPC UA Servers to discover. Instead of starting from sc
 
 ## Deploying an anomaly detection web application as an end consumer of the brokers
 
-A sample anomaly detection web application was created for this end-to-end demo. It has a gRPC stub that calls the brokers' gRPC clients, getting the latest temperature value. It then determines whether this value is an outlier to the dataset using the Local Outlier Factor strategy. The dataset is simply a csv with the numbers between 70-80 repeated several times; therefore, any value significantly outside this range will be seen as an outlier. The web application serves as a log, displaying all the temperature values and the address of the OPC UA Server that sent the values. It shows anomaly values in red. The anomalies always have a value of 120 due to how we set up the `DoSimulation` function in the OPC UA Servers. 
+A sample anomaly detection web application was created for this end-to-end demo. It has a gRPC stub that calls the brokers' gRPC services, getting the latest temperature value. It then determines whether this value is an outlier to the dataset using the Local Outlier Factor strategy. The dataset is simply a csv with the numbers between 70-80 repeated several times; therefore, any value significantly outside this range will be seen as an outlier. The web application serves as a log, displaying all the temperature values and the address of the OPC UA Server that sent the values. It shows anomaly values in red. The anomalies always have a value of 120 due to how we set up the `DoSimulation` function in the OPC UA Servers. 
 
 1. Deploy the anomaly detection app and watch a pod spin up for the app.  
 

--- a/docs/demos/opc-thermometer-demo.md
+++ b/docs/demos/opc-thermometer-demo.md
@@ -177,7 +177,6 @@ A sample anomaly detection web application was created for this end-to-end demo.
    ```sh
    watch kubectl get pods -o wide
    ```
-   ```
 
 2. Determine which port the service is running on.
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -32,7 +32,7 @@ cargo version
 ``` 
 
 ## Build and test Akri's Rust components 
-1. Clone [Akri](https://github.com/deislabs/akri) and navigate to the repo's top folder
+1. Fork and clone [Akri](https://github.com/deislabs/akri). Then, navigate to the repo's top folder.
 
 1. To install Rust and Akri's component's depencies, run Akri's setup script:
     ```sh

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -1,5 +1,5 @@
 # Developer Guide
-This document will walk you through how to set up a local development environment, build Akri component containers, and test Akri using your newly built containers. It also includes instructions on running Akri locally, naming guidelines, and points to our documentation on extending Akri with new Discovery Handlers and brokers.
+This document will walk you through how to set up a local development environment, build Akri component containers, and test Akri using your newly built containers. It also includes instructions on running Akri locally, naming guidelines, and points to documentation on extending Akri with new Discovery Handlers and brokers.
 
 > Note: different tools are needed depending on what parts of Akri you are developing. This document aims to make that clear.
 
@@ -13,14 +13,14 @@ This document will walk you through how to set up a local development environmen
 - [Testing with Debug Echo Discovery Handler](#Testing-with-Debug-Echo-Discovery-Handler)
 - [Discovery Handler and Broker Development](#Discovery-Handler-and-Broker-Development)
 - [Developing Akri's non-Rust components](#developing-akri's-non-rust-components)
-- [Naming Guidelines](Naming-Guidelines)
+- [Naming Guidelines](#Naming-Guidelines)
 
 ## Requirements
 ### Linux Environment
 To develop, you'll **need a Linux environment** whether on amd64 or arm64v8. We recommend using an Ubuntu VM; however, WSL2 should work for building and testing (but has not been extensively tested).
 
 ### Tools for developing Akri's Rust components
-The majority of Akri is written in Rust. To install Rust and Akri's component's depencies, run Akri's setup script:
+The majority of Akri is written in Rust. To install Rust and Akri's component's dependencies, run Akri's setup script:
 ```sh
 ./build/setup.sh
 ```
@@ -51,14 +51,14 @@ cargo version
     cargo build
     ```
 
-    > Note: To build a specific component, use the `-p` paramenter along with the [workspace member](https://github.com/deislabs/akri/blob/main/Cargo.toml). For example, to only build the Agent, run `cargo build -p agent`
+    > Note: To build a specific component, use the `-p` parameter along with the [workspace member](https://github.com/deislabs/akri/blob/main/Cargo.toml). For example, to only build the Agent, run `cargo build -p agent`
 
 1. To run all unit tests:
     ```sh
     cargo test
     ```
 
-    > Note: To test a specific component, use the `-p` paramenter along with the [workspace member](https://github.com/deislabs/akri/blob/main/Cargo.toml). For example, to only test the Agent, run `cargo test -p agent`
+    > Note: To test a specific component, use the `-p` parameter along with the [workspace member](https://github.com/deislabs/akri/blob/main/Cargo.toml). For example, to only test the Agent, run `cargo test -p agent`
 
 ## Running Akri's components locally
 To locally run Akri's Agent, Controller, and Discovery Handlers as part of a Kubernetes cluster, follow these steps:
@@ -133,7 +133,7 @@ In order to cross-build Akri's Rust code for both ARM and x64 containers, severa
   ```
 
 ### Establish a container repository
-Containers for Akri are currently hosted in `ghcr.io/deislabs/akri` using the new [GitHub container registry](https://github.blog/2020-09-01-introducing-github-container-registry/). Any container repository can be used for private containers. If you want to enable GHCR, you can follow the [getting started guide](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry).
+Containers for Akri are currently hosted in `ghcr.io/deislabs/akri` using the new [GitHub container registry](https://github.blog/2020-09-01-introducing-github-container-registry/). Any container repository can be used for private containers. If you want to enable GHCR, you can follow the [getting started guide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 To build containers, log into the desired repository:
 ```sh
@@ -268,7 +268,7 @@ In order to kickstart using and debugging Akri, a debug echo Discovery Handler h
 [documentation](./debugging.md) to start using it.
 
 ## Discovery Handler and Broker Development
-Akri was made to be easily extensible as Discovery Handlers and brokers can be implemented in any language and deployed in their own Pods. Reference the [Discovery Handler development](handler-development.md) and [broker Pod development](broker-development.md) documents to get started, or if you prefer to learn by example, reference the [extending Akri walkthrough](./development-walkthrough).
+Akri was made to be easily extensible as Discovery Handlers and brokers can be implemented in any language and deployed in their own Pods. Reference the [Discovery Handler development](handler-development.md) and [broker Pod development](broker-development.md) documents to get started, or if you prefer to learn by example, reference the [extending Akri walk-through](./development-walkthrough).
 
 ## Developing Akri's non-Rust components
 This document focuses on developing Akri's Rust components; however, Akri has several non-Rust components. Reference their respective READMEs in [Akri's source code](https://github.com/deislabs/akri) for instructions on developing.
@@ -321,7 +321,7 @@ Guidance:
 
 + Kubernetes Convention is that resources (e.g. `DaemonSet`) and CRDs use (upper) CamelCase
 + Akri Convention is that Akri Kubernetes resources be prefixed `akri-`, e.g. `akri-agent-daemonset`
-+ Names combining words should use hypens (`-`) to separate the words e.g. `akri-debug-echo`
++ Names combining words should use hyphens (`-`) to separate the words e.g. `akri-debug-echo`
 
 > **NOTE** `akri-agent-daemonset` contradicts the general principle of not including types, if it had been named after these guidelines were drafted, it would be named `akri-agent`.
 >

--- a/docs/development/test-cases-workflow.md
+++ b/docs/development/test-cases-workflow.md
@@ -9,7 +9,7 @@ File:
 A GitHub workflow that:
 
 + runs Python-based end-to-end [tests](#Tests);
-+ through 5 different Kubernetes [versions](#Versions): 1.16, 1.17, 1.18, 1.19, 1.20;
++ through 6 different Kubernetes [versions](#Versions): 1.16, 1.17, 1.18, 1.19, 1.20, 1.21;
 + on 3 different Kubernetes distros: [K3s](https://k3s.io), [Kubernetes (Kubeadm)](https://kubernetes.io/docs/reference/setup-tools/kubeadm/), [MicroK8s](https://microk8s.io).
 
 ## Tests


### PR DESCRIPTION
This aims to improve the flow of the developer guide by making clearer what dependencies and steps are needed to develop each part of Akri. It makes the document focused on Akri's Rust components. Previously, it mentioned installing and building the ONVIF .NET broker but not the OPC UA .NET broker nor the python applications. To avoid this inconsistency and also bulking up the documentation site with development instructions for Akri's samples, it points to the non-Rust component READMEs in Akri core which this PR adds https://github.com/deislabs/akri/pull/389. 