### PR TITLE
Use proper Rust version and prefix script runs with `./`

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -27,13 +27,13 @@ See the [**developer guide**](../development/development.md) for more informatio
 
 ## Versioning
 
-We follow the [SymVer](https://semver.org/) versioning strategy: \[MAJOR\].\[MINOR\].\[PATCH\]. Our current version can be found in `./version.txt`.
+We follow the [SymVer](https://semver.org/) versioning strategy: \[MAJOR\].\[MINOR\].\[PATCH\]. Our current version can be found in `version.txt`.
 
-* For non-breaking bug fixes and small code changes, \[PATCH\] should be incremented.  This can be accomplished by running `version.sh -u -p`
-* For non-breaking feature changes, \[MINOR\] should be incremented.  This can be accomplished by running `version.sh -u -n`
-* For major and/or breaking changes, \[MAJOR\] should be incremented.  This can be accomplished by running `version.sh -u -m`
+* For non-breaking bug fixes and small code changes, \[PATCH\] should be incremented.  This can be accomplished by running `./version.sh -u -p`
+* For non-breaking feature changes, \[MINOR\] should be incremented.  This can be accomplished by running `./version.sh -u -n`
+* For major and/or breaking changes, \[MAJOR\] should be incremented.  This can be accomplished by running `./version.sh -u -m`
 
-To ensure that all product versioning is consistent, our CI builds will execute `version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, include `[SAME VERSION]` in the pull request title.
+To ensure that all product versioning is consistent, our CI builds will execute `./version.sh -c` to check all known instances of version in our YAML, TOML, and code. This will also check to make sure that version.txt has been changed. If a pull request is needed where the version should not be changed, include `[SAME VERSION]` in the pull request title.
 
 > Note for MacOS users: `version.sh` uses the GNU `sed` command under-the-hood, but MacOS has built-in its own version. We recommend installing the GNU version via `brew install gnu-sed`. Then follow the brew instructions on how to use the installed GNU `sed` instead of the MacOS one.
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,27 +24,31 @@ The majority of Akri is written in Rust. To install Rust and Akri's component's 
 ```sh
 ./build/setup.sh
 ```
-If you previously installed Rust ensure you are using the v1.54.0 toolchain that Akri's build system uses:
+If you previously installed Rust ensure you are using the v1.55.0 toolchain that Akri's build system uses:
 ```sh
-sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.54.0
-rustup default 1.54.0
+sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.55.0
+rustup default 1.55.0
 cargo version
 ``` 
 
 ## Build and test Rust components 
 1. Fork and clone [Akri](https://github.com/deislabs/akri). Then, navigate to the repo's top folder.
 
-1. To install Rust and Akri's component's depencies, run Akri's setup script:
+1. To install Rust and Akri's component's dependencies, run Akri's setup script:
     ```sh
     ./build/setup.sh
     ```
 
-    If you previously installed Rust ensure you are using the v1.54.0 toolchain that Akri's build system uses:
+    If you previously installed Rust, ensure you are using the v1.55.0 toolchain that Akri's build system uses:
     ```sh
-    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.54.0
-    rustup default 1.54.0
-    cargo version
+    sudo curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.55.0
     ``` 
+    Then, configure your current shell to see Cargo and set `v1.55.0` as default toolchain.
+    ```sh
+    source $HOME/.cargo/env
+    rustup default 1.55.0
+    cargo version
+    ```
 
 1. Build Controller, Agent, Discovery Handlers, and udev broker
     ```sh


### PR DESCRIPTION
- Updates installation docs to reflect Akri's current Rust version `v1.55.0`
- Instructs to update version with `./version.sh` instead of `version.sh`